### PR TITLE
align table columns across month

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -172,6 +172,14 @@ h2 {
   color: var(--color-secondary);
 }
 
+th {
+  text-align: left;
+  padding: 0.5em 0;
+  font-size: 2em;
+  font-family: var(--font-cursive);
+  color: var(--color-secondary);
+}
+
 a {
   color: var(--color-link);
   text-decoration: none;

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,14 +116,16 @@
 		</ul>
 	</div>
 
-	{% for month in months %}
-	<h2>{{ month.name() }}</h2>
 	<table>
+		{% for month in months %}
+		<tr>
+			<th colspan="7">{{ month.name() }}</th>
+		</tr>
 		{% for event in month.events %}
 		{% include "shared/event.html" %}
 		{% endfor %}
+		{% endfor %}
 	</table>
-	{% endfor %}
 
 	<p>
 		<a href="/bands">All bands</a> |


### PR DESCRIPTION
### Summary

- make column alignment between month more consistent
  - especially noticable, if you filter by list to only show few results per month
- might be contributing to #3

#### Before

Columns are not aligned between month.
![image](https://user-images.githubusercontent.com/13189449/213916923-4590741a-da19-4aa2-8d94-0d488ce1fde4.png)

#### After (envisioned)

Columns are aligned between month.
![image](https://user-images.githubusercontent.com/13189449/213918131-977ddd43-ba60-4965-bfab-f49524d52ab5.png)

### Test plan

- clone `dancelist-data` repository
- ```bash
  echo "events = ${FULL_PATH_TO_DATA_REPO}" > dancelist.toml
  echo 'bind_address = "127.0.0.1:3002"' >> dancelist.toml
  ```
- `cargo run`
- visit above address and check layout