### PR TITLE
Automatically set timezone based on country/state

### DIFF
--- a/public/scripts/add.js
+++ b/public/scripts/add.js
@@ -1,3 +1,15 @@
+/** The first timezone in the list, which will be the default value. */
+const FIRST_TIMEZONE = "Africa/Abidjan";
+
+/** Timezones to set automatically based on the country and state. */
+const DEFAULT_TIMEZONES = new Map([
+  ["Austria/", "Europe/Vienna"],
+  ["Belgium/", "Europe/Brussels"],
+  ["New Zealand/", "Pacific/Auckland"],
+  ["UK/", "Europe/London"],
+  ["USA/AZ", "US/Mountain"],
+]);
+
 function add_input(list, name, type, id, datalist) {
   var input = document.createElement("input");
   input.setAttribute("type", type);
@@ -49,13 +61,30 @@ function update_datetimes() {
   });
 }
 
+function update_timezone() {
+  let country = document.getElementById("country").value;
+  let state = document.getElementById("state").value;
+  let country_state = country + "/" + state;
+  let timezone_field = document.getElementById("timezone");
+
+  if (
+    timezone.value == FIRST_TIMEZONE &&
+    DEFAULT_TIMEZONES.has(country_state)
+  ) {
+    timezone_field.value = DEFAULT_TIMEZONES.get(country_state);
+  }
+}
+
 function initialise() {
   document.getElementById("links_list").oninput = update_inputs;
   document.getElementById("bands_list").oninput = update_inputs;
   document.getElementById("callers_list").oninput = update_inputs;
   document.getElementById("with_time").onchange = update_datetimes;
+  document.getElementById("country").onchange = update_timezone;
+  document.getElementById("state").onchange = update_timezone;
 
   update_datetimes();
+  update_timezone();
 }
 
 window.onload = initialise;

--- a/public/scripts/add.js
+++ b/public/scripts/add.js
@@ -1,15 +1,6 @@
 /** The first timezone in the list, which will be the default value. */
 const FIRST_TIMEZONE = "Africa/Abidjan";
 
-/** Timezones to set automatically based on the country and state. */
-const DEFAULT_TIMEZONES = new Map([
-  ["Austria/", "Europe/Vienna"],
-  ["Belgium/", "Europe/Brussels"],
-  ["New Zealand/", "Pacific/Auckland"],
-  ["UK/", "Europe/London"],
-  ["USA/AZ", "US/Mountain"],
-]);
-
 function add_input(list, name, type, id, datalist) {
   var input = document.createElement("input");
   input.setAttribute("type", type);

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,6 +15,14 @@
 use chrono::{DateTime, FixedOffset, NaiveDateTime, Offset, TimeZone};
 use chrono_tz::Tz;
 
+pub const DEFAULT_TIMEZONES: [((&str, Option<&str>), Tz); 5] = [
+    (("Austria", None), Tz::Europe__Vienna),
+    (("Belgium", None), Tz::Europe__Brussels),
+    (("New Zealand", None), Tz::Pacific__Auckland),
+    (("UK", None), Tz::Europe__London),
+    (("USA", Some("AZ")), Tz::US__Mountain),
+];
+
 fn to_fixed_offset(date_time: DateTime<Tz>) -> DateTime<FixedOffset> {
     let fixed_offset = date_time.offset().fix();
     date_time.with_timezone(&fixed_offset)

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,12 +15,34 @@
 use chrono::{DateTime, FixedOffset, NaiveDateTime, Offset, TimeZone};
 use chrono_tz::Tz;
 
-pub const DEFAULT_TIMEZONES: [((&str, Option<&str>), Tz); 5] = [
+pub const DEFAULT_TIMEZONES: [((&str, Option<&str>), Tz); 27] = [
     (("Austria", None), Tz::Europe__Vienna),
     (("Belgium", None), Tz::Europe__Brussels),
+    (("Bulgaria", None), Tz::Europe__Sofia),
+    (("Canada", Some("Ontario")), Tz::Canada__Eastern),
+    (("Czechia", None), Tz::Europe__Prague),
+    (("France", None), Tz::Europe__Paris),
+    (("Germany", None), Tz::Europe__Berlin),
+    (("Iraq", None), Tz::Asia__Baghdad),
+    (("Ireland", None), Tz::Europe__Dublin),
+    (("Italy", None), Tz::Europe__Rome),
+    (("Latvia", None), Tz::Europe__Riga),
+    (("Lithuania", None), Tz::Europe__Vilnius),
+    (("Netherlands", None), Tz::Europe__Amsterdam),
     (("New Zealand", None), Tz::Pacific__Auckland),
+    (("Norway", None), Tz::Europe__Oslo),
+    (("Poland", None), Tz::Europe__Warsaw),
+    (("Portugal", None), Tz::Europe__Lisbon),
+    (("Slovenia", None), Tz::Europe__Ljubljana),
+    (("Spain", None), Tz::Europe__Madrid),
+    (("Sweden", None), Tz::Europe__Stockholm),
+    (("Switzerland", None), Tz::Europe__Zurich),
+    (("Turkey", None), Tz::Europe__Istanbul),
     (("UK", None), Tz::Europe__London),
     (("USA", Some("AZ")), Tz::US__Mountain),
+    (("USA", Some("CA")), Tz::US__Pacific),
+    (("USA", Some("MA")), Tz::US__Eastern),
+    (("USA", Some("NY")), Tz::US__Eastern),
 ];
 
 fn to_fixed_offset(date_time: DateTime<Tz>) -> DateTime<FixedOffset> {

--- a/templates/add.html
+++ b/templates/add.html
@@ -4,6 +4,14 @@
 <head>
 	<title>Add event</title>
 	<link rel="stylesheet" type="text/css" href="/stylesheets/main.css" />
+	<script type="text/javascript">
+		/** Timezones to set automatically based on the country and state. */
+		const DEFAULT_TIMEZONES = new Map([
+			{% for tz in crate::util::DEFAULT_TIMEZONES %}
+			["{{ tz.0.0 }}/{{ tz.0.1.unwrap_or_default() }}", "{{ tz.1 }}"],
+			{% endfor %}
+		]);
+	</script>
 	<script type="text/javascript" src="/scripts/add.js"></script>
 </head>
 

--- a/templates/add.html
+++ b/templates/add.html
@@ -141,7 +141,7 @@
 				</datalist>
 			</li>
 			<li>
-				<label for="styles" class="required">Dance styles</label>
+				<label class="required">Dance styles</label>
 				<fieldset class="styles">
 					<ul>
 						{% for style in crate::model::dancestyle::DanceStyle::values() %}

--- a/templates/add.html
+++ b/templates/add.html
@@ -58,38 +58,6 @@
 				</fieldset>
 			</li>
 			<li>
-				<label for="with_time">Include time</label>
-				<input name="with_time" id="with_time" type="checkbox" value="true" {{ form.with_time()|checked_if_true }}/>
-			</li>
-			<li class="times">
-				<label for="start" class="required">Start time</label>
-				<input name="start" id="start" type="datetime-local" required="required" value="{{ form.start_string() }}"/>
-			</li>
-			<li class="times">
-				<label for="end" class="required">End time</label>
-				<input name="end" id="end" type="datetime-local" required="required" value="{{ form.end_string() }}"/>
-			</li>
-			<li class="times">
-				<label for="timezone" class="required">Timezone</label>
-				<select name="timezone" id="timezone" required="required">
-					{% for timezone in chrono_tz::TZ_VARIANTS %}
-					{% if Some(timezone.clone()) == form.timezone %}
-					<option value="{{ timezone }}" selected="selected">{{ timezone }}</option>
-					{% else %}
-					<option value="{{ timezone }}">{{ timezone }}</option>
-					{% endif %}
-					{% endfor %}
-				</select>
-			</li>
-			<li class="dates">
-				<label for="start_date" class="required">Start date</label>
-				<input name="start_date" id="start_date" type="date" required="required" value="{{ form.start_date_string() }}"/>
-			</li>
-			<li class="dates">
-				<label for="end_date" class="required">End date</label>
-				<input name="end_date" id="end_date" type="date" required="required" value="{{ form.end_date_string() }}"/>
-			</li>
-			<li>
 				<label for="country" class="required">Country</label>
 				<p>The country in which the event will take place.</p>
 				<input
@@ -139,6 +107,38 @@
 					<option>{{ city }}</option>
 					{% endfor %} {% endfor %}
 				</datalist>
+			</li>
+			<li>
+				<label for="with_time">Include time</label>
+				<input name="with_time" id="with_time" type="checkbox" value="true" {{ form.with_time()|checked_if_true }}/>
+			</li>
+			<li class="times">
+				<label for="start" class="required">Start time</label>
+				<input name="start" id="start" type="datetime-local" required="required" value="{{ form.start_string() }}"/>
+			</li>
+			<li class="times">
+				<label for="end" class="required">End time</label>
+				<input name="end" id="end" type="datetime-local" required="required" value="{{ form.end_string() }}"/>
+			</li>
+			<li class="times">
+				<label for="timezone" class="required">Timezone</label>
+				<select name="timezone" id="timezone" required="required">
+					{% for timezone in chrono_tz::TZ_VARIANTS %}
+					{% if Some(timezone.clone()) == form.timezone %}
+					<option value="{{ timezone }}" selected="selected">{{ timezone }}</option>
+					{% else %}
+					<option value="{{ timezone }}">{{ timezone }}</option>
+					{% endif %}
+					{% endfor %}
+				</select>
+			</li>
+			<li class="dates">
+				<label for="start_date" class="required">Start date</label>
+				<input name="start_date" id="start_date" type="date" required="required" value="{{ form.start_date_string() }}"/>
+			</li>
+			<li class="dates">
+				<label for="end_date" class="required">End date</label>
+				<input name="end_date" id="end_date" type="date" required="required" value="{{ form.end_date_string() }}"/>
 			</li>
 			<li>
 				<label class="required">Dance styles</label>

--- a/templates/add.html
+++ b/templates/add.html
@@ -108,6 +108,9 @@
 			</li>
 			<li>
 				<label for="state">State</label>
+				<p>
+					Leave blank if the country does not have states.
+				</p>
 				<input name="state" id="state" type="text" list="states" value="{{ form.state.as_deref().unwrap_or_default() }}"/>
 				<datalist id="states">
 					{% for country in countries %} {% for state in country.states %}


### PR DESCRIPTION
This implements one of the suggestions in #310, to automatically set the timezone in the add event form based on the country and state. These defaults are hardcoded for now, and can still be overridden by the user manually choosing a timezone.